### PR TITLE
Fix build error by old github.com/rjeczalik/notify

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,36 +3,48 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:ec1e8d27ef73eb25966952b44c35b5573d591213fe4900471c72a3cd0e28940e"
   name = "github.com/bmatcuk/doublestar"
   packages = ["."]
+  pruneopts = ""
   revision = "54c073d0225fcec2f0865dc8530ff0477fd91615"
 
 [[projects]]
+  digest = "1:9ed055a3aae12576c784609f6894cc05ea64f24c3a4859f1d0052bfea1bdde0e"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = ""
   revision = "8099a9787ce5dc5984ed879a3bda47dc730a8e97"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:7143292549152d009ca9e9c493b74736a2ebd93f921bea8a4b308d7cc5edc6b3"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
-  revision = "52ae50d8490436622a8941bd70c3dbe0acdd4bbf"
-  version = "v0.9.0"
+  pruneopts = ""
+  revision = "0f065fa99b48b842c3fd3e2c8b194c6f2b69f6b8"
+  version = "v0.9.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:677e38cad6833ad266ec843739d167755eda1e6f2d8af1c63102b0426ad820db"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4242ed586f338d176fa29d8226f650a37aa03e057baf78ed65c4f6a3f251a874"
+  input-imports = [
+    "github.com/bmatcuk/doublestar",
+    "github.com/google/go-cmp/cmp",
+    "github.com/rjeczalik/notify",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,8 +71,8 @@
   name = "github.com/bmatcuk/doublestar"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/rjeczalik/notify"
+  version = "0.9.1"
 
 [[constraint]]
   name = "github.com/google/go-cmp"

--- a/vendor/github.com/rjeczalik/notify/.travis.yml
+++ b/vendor/github.com/rjeczalik/notify/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
- - 1.7.5
+ - 1.10.x
  - tip
 
 os:

--- a/vendor/github.com/rjeczalik/notify/appveyor.yml
+++ b/vendor/github.com/rjeczalik/notify/appveyor.yml
@@ -7,16 +7,20 @@ clone_folder: c:\projects\src\github.com\rjeczalik\notify
 environment:
  PATH: c:\projects\bin;%PATH%
  GOPATH: c:\projects
- NOTIFY_TIMEOUT: 5s
+ NOTIFY_TIMEOUT: 10s
+ GOVERSION: 1.10.3
 
 install:
+ - rmdir c:\go /s /q
+ - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+ - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
+
+ - cd %APPVEYOR_BUILD_FOLDER%
  - go version
- - go get -v -t ./...
 
 build_script:
- - go tool vet -all .
  - go build ./...
- - go test -v -timeout 60s -race ./...
+ - go test -v -timeout 120s -race ./...
 
 test: off
 

--- a/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
@@ -48,7 +48,7 @@ var wg sync.WaitGroup      // used to wait until the runloop starts
 // started and is ready via the wg. It also serves purpose of a dummy source,
 // thanks to it the runloop does not return as it also has at least one source
 // registered.
-var source = C.CFRunLoopSourceCreate(nil, 0, &C.CFRunLoopSourceContext{
+var source = C.CFRunLoopSourceCreate(C.kCFAllocatorDefault, 0, &C.CFRunLoopSourceContext{
 	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
 })
 
@@ -166,8 +166,8 @@ func (s *stream) Start() error {
 		return nil
 	}
 	wg.Wait()
-	p := C.CFStringCreateWithCStringNoCopy(nil, C.CString(s.path), C.kCFStringEncodingUTF8, nil)
-	path := C.CFArrayCreate(nil, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
+	p := C.CFStringCreateWithCStringNoCopy(C.kCFAllocatorDefault, C.CString(s.path), C.kCFStringEncodingUTF8, C.kCFAllocatorDefault)
+	path := C.CFArrayCreate(C.kCFAllocatorDefault, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
 	ctx := C.FSEventStreamContext{}
 	ref := C.EventStreamCreate(&ctx, C.uintptr_t(s.info), path, C.FSEventStreamEventId(atomic.LoadUint64(&since)), latency, flags)
 	if ref == nilstream {


### PR DESCRIPTION
I updated `Gopkg.toml` and run `dep ensure` to use [github.com/rjeczalik/notify@v0.9.1](https://github.com/rjeczalik/notify/releases/tag/v0.9.1)

This PullRequest also relates modd's issue.
https://github.com/cortesi/modd/issues/57

```
$ go version
go version go1.10.4 darwin/amd64
$ git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ go test ./...
# github.com/cortesi/moddwatch/vendor/github.com/rjeczalik/notify
vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go:51: cannot use nil as type _Ctype_CFAllocatorRef in argument to func literal
vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go:169: cannot use nil as type _Ctype_CFAllocatorRef in argument to _Cfunc_CFStringCreateWithCStringNoCopy
vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go:170: cannot use nil as type _Ctype_CFAllocatorRef in argument to func literal
FAIL    github.com/cortesi/moddwatch [build failed]
ok      github.com/cortesi/moddwatch/filter     (cached)
$ git co fix_notify_dependency
Switched to branch 'fix_notify_dependency'
$ go test ./...
ok      github.com/cortesi/moddwatch    4.291s
ok      github.com/cortesi/moddwatch/filter     (cached)
```

